### PR TITLE
Support Erb Files Too

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,3 +1,3 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hogan,*.hulk,*.hjs set filetype=html syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.{mustache,handlebars,hbs,hogan,hulk,hjs}{,.erb} set filetype=html syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif


### PR DESCRIPTION
In Rails we can have files like "foo.hbs.erb", which, at this point, aren't supported by this plugin. This change was available in nono/vim-handlebars (see https://github.com/nono/vim-handlebars/blob/f419dd0fe0f8df1712285a06260d809dd343f776/ftdetect/handlebars.vim#L1-L3). This commit brings this change to this plugin.
