### PR TITLE
Support inverted sections

### DIFF
--- a/syntax/mustache.vim
+++ b/syntax/mustache.vim
@@ -43,7 +43,7 @@ syntax match mustacheError '}}}\?'
 syntax match mustacheInsideError '{{[{#<>=!\/]\?'
 syntax region mustacheInside start=/{{/ end=/}}}\?/ keepend containedin=TOP,@htmlMustacheContainer
 syntax match mustacheOperators '=\|\.\|/' contained containedin=mustacheInside,@htmlMustacheContainer
-syntax region mustacheSection start='{{[#/]'lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
+syntax region mustacheSection start='{{[#^/]'lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax region mustachePartial start=/{{[<>]/lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax region mustacheMarkerSet start=/{{=/lc=2 end=/=}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax match mustacheHandlebars '{{\|}}' contained containedin=mustacheInside,@htmlMustacheContainer


### PR DESCRIPTION
From mustache(5):

> An inverted section begins with a caret (hat) and ends with a slash.
> That is `{{^person}}` begins a "person" inverted section while
> `{{/person}}` ends it.
