### PR TITLE
Set filetype to mustache

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,3 +1,3 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hogan,*.hulk,*.hjs set filetype=html syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hogan,*.hulk,*.hjs set filetype=mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif


### PR DESCRIPTION
Otherwise, the `syntax` may get overridden during the VIM boot process.
Since the mustache syntax imports HTML syntax, there doesn't seem to be a
reason for continuing to use the `html` filetype.
