### PR TITLE
Update readme to not assume a git repo in ~/.vim directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A vim plugin for working with [mustache][mustache] and
 ### Install for pathogen
 
     cd ~/.vim/
-    git submodule add git://github.com/mustache/vim-mustache-handlebars.git bundle/mustache
+    git clone git://github.com/mustache/vim-mustache-handlebars.git bundle/mustache
     vim bundle/mustache/example.mustache
 
 Get [pathogen][pathogen].


### PR DESCRIPTION
Instructions in current readme suggest to add as `git submodule add ...` in `~/.vim` directory.

Not everyone has a dedicated repo for their vim config, so this update would make the readme more universal.

Oh, and by the way, thanks for the awesome work!
:+1: 
