### PR TITLE
Add *.hdbs extension to ftdetect

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,3 +1,3 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hogan,*.hulk,*.hjs set filetype=html syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.mustache,*.handlebars,*.hbs,*.hdbs,*.hogan,*.hulk,*.hjs set filetype=html syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif


### PR DESCRIPTION
Zendesk Apps require handlebar templates to end in .hdbs.
This change adds detection of handlebar templates with this extension.
http://developer.zendesk.com/documentation/apps/templates.html
