### PR TITLE
Added support for replaceable sections

### DIFF
--- a/syntax/mustache.vim
+++ b/syntax/mustache.vim
@@ -40,10 +40,10 @@ else
 endif
 
 syntax match mustacheError '}}}\?'
-syntax match mustacheInsideError '{{[{#<>=!\/]\?'
+syntax match mustacheInsideError '{{[{$#<>=!\/]\?'
 syntax region mustacheInside start=/{{/ end=/}}}\?/ keepend containedin=TOP,@htmlMustacheContainer
 syntax match mustacheOperators '=\|\.\|/' contained containedin=mustacheInside,@htmlMustacheContainer
-syntax region mustacheSection start='{{[#^/]'lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
+syntax region mustacheSection start='{{[$#^/]'lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax region mustachePartial start=/{{[<>]/lc=2 end=/}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax region mustacheMarkerSet start=/{{=/lc=2 end=/=}}/me=e-2 contained containedin=mustacheInside,@htmlMustacheContainer
 syntax match mustacheHandlebars '{{\|}}' contained containedin=mustacheInside,@htmlMustacheContainer


### PR DESCRIPTION
This adds correct syntax highlighting for the replaceable blocks as described in
https://github.com/mustache/spec/issues/38 and implemented in Hogan.js and
mustache-java.

This turns this: 

![screen shot 2014-06-30 at 15 26 28](https://cloud.githubusercontent.com/assets/1446145/3430555/b9817f5c-0062-11e4-8079-7351826e7129.png)

Into this:

![screen shot 2014-06-30 at 15 24 21](https://cloud.githubusercontent.com/assets/1446145/3430557/bd118338-0062-11e4-8aef-d661c966f3d5.png)

Pretty simple.
