### PR TITLE
Update install instructions for Vundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Get [pathogen][pathogen].
 
 ### Install for vundle
 
-Add `Plugin 'mustache/vim-mustache-handlebars'` to your `.vimrc` and do a `:BundleInstall`.
+Add `Plugin 'mustache/vim-mustache-handlebars'` to your `.vimrc` and do a
+`:PluginInstall`.
 
 ### Manually Install
 


### PR DESCRIPTION
- `PluginInstall` is new install command for vundle bundles
- Source: https://github.com/gmarik/Vundle.vim
