### PR TITLE
Added 'hdbs' to recognized Handlebars suffices

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,4 +1,4 @@
 if has("autocmd")
   au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
-  au  BufNewFile,BufRead *.handlebars,*.hbs,*.hdbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.handlebars,*.hdbs,*.hbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif

--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,4 +1,4 @@
 if has("autocmd")
   au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
-  au  BufNewFile,BufRead *.handlebars,*.hbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.handlebars,*.hbs,*.hdbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif


### PR DESCRIPTION
Allows you to use `.hdbs` as a suffix for handlebars templates. When developing apps for Zendesk, I'm required to use this extension. Therefore, it would be far more useful to have it by default and not something I need to remind people to update their .vimrc with.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mustache/vim-mustache-handlebars/32)

<!-- Reviewable:end -->
