### PR TITLE
Fix Vundle install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Get [pathogen][pathogen].
 
 ### Install for vundle
 
-Add `Plugin 'mustache/vim-mustache-handlebars'` to your `.vimrc` and do a
+Add `Plugin 'mustache/vim-mustache-handlebars.git'` to your `.vimrc` and do a
 `:PluginInstall`.
 
 ### Manually Install


### PR DESCRIPTION
I've got a 404 from Vundle at the first try, adding `.git` to the URL seemed to fix it.