### PR TITLE
Evaluate handlebars indent in mustache files

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,4 +1,4 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim indent/handlebars.vim
   au  BufNewFile,BufRead *.handlebars,*.hdbs,*.hbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif


### PR DESCRIPTION
It seems like mustache files don't get the right indentation. Opening the `example.mustache` file sets the filetype to `html.mustache`, as it should, but the indentexpr is still `HtmlIndent()`.

This PR should fix the issue. It evaluates `indent/handlebars.vim`, so that the indentation is set to the one used for handlebars (the only one in the project).

Funnily enough, some handlebars files occasionally have `HtmlIndent()` as their indentexpr, but I haven't been able to figure out when it happens.