### PR TITLE
Hanging attributes

### DIFF
--- a/ftdetect/mustache.vim
+++ b/ftdetect/mustache.vim
@@ -1,4 +1,4 @@
 if has("autocmd")
-  au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
+  au  BufNewFile,BufRead *.mustache,*.hogan,*.hulk,*.hjs set filetype=html.mustache syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim indent/handlebars.vim
   au  BufNewFile,BufRead *.handlebars,*.hbs set filetype=html.handlebars syntax=mustache | runtime! ftplugin/mustache.vim ftplugin/mustache*.vim ftplugin/mustache/*.vim
 endif

--- a/indent/handlebars.vim
+++ b/indent/handlebars.vim
@@ -72,15 +72,16 @@ function! GetHandlebarsIndent(...)
     " Force HTML indent to not keep state
     let b:indent.lnum = -1
   endif
-  let lnum = prevnonblank(v:lnum-1)
-  let line = getline(lnum)
+  let plnum = prevnonblank(v:lnum-1)
+  let pline = getline(plnum)
   let cline = getline(v:lnum)
 
   " all indent rules only apply if the block opening/closing
   " tag is on a separate line
 
   " indent after block {{#block
-  if line =~# '\v\s*\{\{\#.*\s*'
+  if pline =~# '\v\{\{\#.*\s*' &&
+        \ pline !~# '{{#\(.\{}\)\s.\{}}}.*{{\/\1}}'
     let ind = ind + sw
   endif
   " unindent after block close {{/block}}
@@ -92,7 +93,7 @@ function! GetHandlebarsIndent(...)
     let ind = ind - sw
   endif
   " indent again after {{else}}
-  if line =~# '\v^\s*\{\{else.*\}\}\s*$'
+  if pline =~# '\v^\s*\{\{else.*\}\}\s*$'
     let ind = ind + sw
   endif
 

--- a/indent/handlebars.vim
+++ b/indent/handlebars.vim
@@ -79,6 +79,30 @@ function! GetHandlebarsIndent(...)
   " all indent rules only apply if the block opening/closing
   " tag is on a separate line
 
+  " check for a hanging attribute
+  if synIDattr(synID(v:lnum, 1, 1), "name") =~ 'mustache\%(Inside\|Section\)' &&
+        \ cline =~ '^\s*\k\+='
+    let [line, col] = searchpos('{{\#\=\k\+\s\+\zs\k\+=', 'Wbn', plnum)
+    if line == plnum
+      return col - 1
+    endif
+  endif
+
+  " check for a closing }}, indent according to the opening one
+  if pline =~# '}}$' && pline !~# '^\s*{{'
+    " Is it a block component?
+    let [line, col] = searchpos('{{#', 'Wbn')
+    if line > 0
+      return (col - 1) + sw
+    endif
+
+    " Is it a single component?
+    let [line, col] = searchpos('{{', 'Wbn')
+    if line > 0
+      return (col - 1)
+    endif
+  endif
+
   " indent after block {{#block
   if pline =~# '\v\{\{\#.*\s*' &&
         \ pline !~# '{{#\(.\{}\)\s.\{}}}.*{{\/\1}}'

--- a/indent/handlebars.vim
+++ b/indent/handlebars.vim
@@ -81,8 +81,8 @@ function! GetHandlebarsIndent(...)
 
   " check for a hanging attribute
   if synIDattr(synID(v:lnum, 1, 1), "name") =~ 'mustache\%(Inside\|Section\)'
-    let hanging_attribute_pattern = '{{\#\=\k\+\s\+\zs\k\+='
-    let just_component_pattern = '^\s*{{\k\+\s*$'
+    let hanging_attribute_pattern = '{{\#\=\%(\k\|[/-]\)\+\s\+\zs\k\+='
+    let just_component_pattern = '^\s*{{\%(\k\|[/-]\)\+\s*$'
 
     if pline =~ hanging_attribute_pattern
       " {{component attribute=value

--- a/indent/handlebars.vim
+++ b/indent/handlebars.vim
@@ -80,11 +80,21 @@ function! GetHandlebarsIndent(...)
   " tag is on a separate line
 
   " check for a hanging attribute
-  if synIDattr(synID(v:lnum, 1, 1), "name") =~ 'mustache\%(Inside\|Section\)' &&
-        \ cline =~ '^\s*\k\+='
-    let [line, col] = searchpos('{{\#\=\k\+\s\+\zs\k\+=', 'Wbn', plnum)
-    if line == plnum
-      return col - 1
+  if synIDattr(synID(v:lnum, 1, 1), "name") =~ 'mustache\%(Inside\|Section\)'
+    let hanging_attribute_pattern = '{{\#\=\k\+\s\+\zs\k\+='
+    let just_component_pattern = '^\s*{{\k\+\s*$'
+
+    if pline =~ hanging_attribute_pattern
+      " {{component attribute=value
+      "             other=value}}
+      let [line, col] = searchpos(hanging_attribute_pattern, 'Wbn', plnum)
+      if line == plnum
+        return col - 1
+      endif
+    elseif pline =~ just_component_pattern
+      " {{component
+      "   attribute=value}}
+      return indent(plnum) + sw
     endif
   endif
 


### PR DESCRIPTION
This PR implements a "hanging" attribute style. If the first line of the component has at least one attribute set on that line, the rest align according to that. So, it looks like this:

``` handlebars
{{foo-bar one="two"
          two="three"
          four="five"}}
```

If the first line only has the component name, and not an attribute, it indents like it did before.

Unfortunately, I branched this PR off from my own master, which includes PRs #53 and #52. Depending on what you decide, I can rebase this on top of your master, but for now, I'll just leave it here for consideration as-is.