### PR TITLE
Add vim-commentary support

### DIFF
--- a/ftplugin/mustache.vim
+++ b/ftplugin/mustache.vim
@@ -21,7 +21,7 @@ if exists("loaded_matchit") && exists("b:match_words")
   \ . '\%({{\)\@<=/\s*\1\s*}}'
 endif
 
-" Vim-commentary support
+" Set template for comment
 setlocal commentstring={{!--\ %s\ --}}
 
 if exists("g:mustache_abbreviations")

--- a/ftplugin/mustache.vim
+++ b/ftplugin/mustache.vim
@@ -21,6 +21,9 @@ if exists("loaded_matchit") && exists("b:match_words")
   \ . '\%({{\)\@<=/\s*\1\s*}}'
 endif
 
+" Vim-commentary support
+setlocal commentstring={{!--\ %s\ --}}
+
 if exists("g:mustache_abbreviations")
   inoremap <buffer> {{{ {{{}}}<left><left><left>
   inoremap <buffer> {{ {{}}<left><left>


### PR DESCRIPTION
Set `commentstring` to make tpope's [vim-commentary](https://github.com/tpope/vim-commentary) work out of the box with this plugin.