### PR TITLE
Add adjacent comment/HTML to example file for testing

### DIFF
--- a/example.mustache
+++ b/example.mustache
@@ -36,6 +36,12 @@
 
       Another {{!-- comment --}}, this one is a block comment.
 
+      HTML elements should be able to follow:
+      {{! comments }}
+      <span class="class">Hello</span>
+      {{!-- and block comments --}}
+      <span class="class">Hello</span>
+
       {{!-- TODO: some remark
       <div>
         Multiline {{comments}} with


### PR DESCRIPTION
Some syntax problems were happening when HTML came immediately after certain types of comments (#29, #58, #61); added those cases here to the example file for more robust testing.